### PR TITLE
Support for third-party tools

### DIFF
--- a/adjust_cvss.py
+++ b/adjust_cvss.py
@@ -43,11 +43,11 @@ def adjust_cvss(args):
     args.patterns = [parse_pattern(p) for p in args.patterns if p]
 
     print('Given patterns:')
-    for idp, sp in args.patterns:
+    for input_id_pattern, input_score_pattern in args.patterns:
         print(
             'IDs: {id_pattern}    scores: {score_pattern}'.format(
-                id_pattern=idp,
-                score_pattern=sp
+                id_pattern=input_id_pattern,
+                score_pattern=input_score_pattern
             )
         )
 
@@ -56,31 +56,31 @@ def adjust_cvss(args):
 
     for run in s.get('runs', []):
         # tool --> extensions --> rules match
-        for ext in run.get('tool', {}).get('extensions', []):
-            for rule in ext.get('rules', []):
+        for extension in run.get('tool', {}).get('extensions', []):
+            for rule in extension.get('rules', []):
                 props = rule.get('properties', [])
 
-                qip = props.get('id', '')
+                rule_id = props.get('id', '')
                 cvss = props.get('security-severity', None)
 
                 if cvss:
-                    for idp, sp in args.patterns:
-                        if match(idp, qip):
+                    for input_id_pattern, input_score_pattern in args.patterns:
+                        if match(input_id_pattern, rule_id):
                             print('adjusted')
-                            props['security-severity'] = sp
+                            props['security-severity'] = input_score_pattern
 
         # tool --> driver --> rules match
         for rule in run.get('tool', {})['driver'].get('rules', []):
             props = rule.get('properties', [])
-            qip = rule.get('id', [])
+            rule_id = rule.get('id', [])
             
             cvss = props.get('security-severity', None)
 
             if cvss:
-                for idp, sp in args.patterns:
-                    if match(idp, qip):
+                for input_id_pattern, input_score_pattern in args.patterns:
+                    if match(input_id_pattern, rule_id):
                         print('adjusted')
-                        props['security-severity'] = sp
+                        props['security-severity'] = input_score_pattern
 
     with open(args.output, 'w') as f:
         json.dump(s, f, indent=2)

--- a/adjust_cvss.py
+++ b/adjust_cvss.py
@@ -70,19 +70,17 @@ def adjust_cvss(args):
                             props['security-severity'] = sp
 
         # tool --> driver match
-        for dri in run.get('tool', {}).get('driver', {}):
-            print(dri)
-            for rule in dri.get('rules', []):
-                props = rule.get('properties', [])
-                qip = rule.get('id', [])
-                
-                cvss = props.get('security-severity', None)
+        for rule in run.get('tool', {})['driver'].get('rules', []):
+            props = rule.get('properties', [])
+            qip = rule.get('id', [])
+            
+            cvss = props.get('security-severity', None)
 
-                if cvss:
-                    for idp, sp in args.patterns:
-                        if match(idp, qip):
-                            print('adjusted')
-                            props['security-severity'] = sp
+            if cvss:
+                for idp, sp in args.patterns:
+                    if match(idp, qip):
+                        print('adjusted')
+                        props['security-severity'] = sp
 
     with open(args.output, 'w') as f:
         json.dump(s, f, indent=2)

--- a/adjust_cvss.py
+++ b/adjust_cvss.py
@@ -70,8 +70,8 @@ def adjust_cvss(args):
                             props['security-severity'] = sp
 
         # tool --> driver match
-        for ext in run.get('tool', {}).get('driver', []):
-            for rule in ext.get('rules', []):
+        for dri in run.get('tool', {}).get('driver', {}):
+            for rule in dri.get('rules', []):
                 props = rule.get('properties', [])
                 qip = rule.get('id', [])
                 

--- a/adjust_cvss.py
+++ b/adjust_cvss.py
@@ -55,7 +55,7 @@ def adjust_cvss(args):
         s = json.load(f)
 
     for run in s.get('runs', []):
-        # tool --> extensions match
+        # tool --> extensions --> rules match
         for ext in run.get('tool', {}).get('extensions', []):
             for rule in ext.get('rules', []):
                 props = rule.get('properties', [])
@@ -69,7 +69,7 @@ def adjust_cvss(args):
                             print('adjusted')
                             props['security-severity'] = sp
 
-        # tool --> driver match
+        # tool --> driver --> rules match
         for rule in run.get('tool', {})['driver'].get('rules', []):
             props = rule.get('properties', [])
             qip = rule.get('id', [])

--- a/adjust_cvss.py
+++ b/adjust_cvss.py
@@ -55,11 +55,26 @@ def adjust_cvss(args):
         s = json.load(f)
 
     for run in s.get('runs', []):
+        # tool --> extensions match
         for ext in run.get('tool', {}).get('extensions', []):
             for rule in ext.get('rules', []):
                 props = rule.get('properties', [])
 
                 qip = props.get('id', '')
+                cvss = props.get('security-severity', None)
+
+                if cvss:
+                    for idp, sp in args.patterns:
+                        if match(idp, qip):
+                            print('adjusted')
+                            props['security-severity'] = sp
+
+        # tool --> driver match
+        for ext in run.get('tool', {}).get('driver', []):
+            for rule in ext.get('rules', []):
+                props = rule.get('properties', [])
+                qip = rule.get('id', [])
+                
                 cvss = props.get('security-severity', None)
 
                 if cvss:

--- a/adjust_cvss.py
+++ b/adjust_cvss.py
@@ -71,6 +71,7 @@ def adjust_cvss(args):
 
         # tool --> driver match
         for dri in run.get('tool', {}).get('driver', {}):
+            print(dri)
             for rule in dri.get('rules', []):
                 props = rule.get('properties', [])
                 qip = rule.get('id', [])


### PR DESCRIPTION
This PR adds support for tools (like Trivy and Checkmarx) that define their rules under:

`runs` --> `tool` --> `driver` --> `rules` 

instead of:

`runs` --> `tool` --> `extensions` --> `rules`

Fixes #2 , and tested for backwards compatibility with CodeQL.