### PR TITLE
Use UTF-8 for reading/writing sarif file

### DIFF
--- a/adjust_cvss.py
+++ b/adjust_cvss.py
@@ -51,7 +51,7 @@ def adjust_cvss(args):
             )
         )
 
-    with open(args.input, 'r') as f:
+    with open(args.input, 'r', encoding="utf-8") as f:
         s = json.load(f)
 
     for run in s.get('runs', []):
@@ -82,7 +82,7 @@ def adjust_cvss(args):
                         print('adjusted')
                         props['security-severity'] = input_score_pattern
 
-    with open(args.output, 'w') as f:
+    with open(args.output, 'w', encoding="utf-8") as f:
         json.dump(s, f, indent=2)
 
 


### PR DESCRIPTION
This PR adjusts the reading/writing of sarif files to use utf-8 encoding. 

Before this change, I had to add this to my adjust-cvss step:
```
      env:
        PYTHONUTF8: "1"
        PYTHONIOENCODING: "UTF-8"
```

Otherwise I get an error like this:
```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 297884: character maps to <undefined>
```

It appears to be using cp1252. Here's the full trace

```
Traceback (most recent call last):
  File "D:\a\_actions\advanced-security\adjust-cvss\74da0f04ca3a1d2cbfcf140bf49a2039a783800a\adjust_cvss.py", line 122, in <module>
    main()
  File "D:\a\_actions\advanced-security\adjust-cvss\74da0f04ca3a1d2cbfcf140bf49a2039a783800a\adjust_cvss.py", line 119, in main
    adjust_cvss(args)
  File "D:\a\_actions\advanced-security\adjust-cvss\74da0f04ca3a1d2cbfcf140bf49a2039a783800a\adjust_cvss.py", line 55, in adjust_cvss
    s = json.load(f)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 297884: character maps to <undefined>
```

Note that the job also has `    runs-on: windows-latest`
