### PR TITLE
Potential fix for code scanning alert no. 61: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   analyze:
     name: Analyze
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality
@@ -41,13 +41,13 @@ jobs:
         javatest/build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
       with:
         upload: False
         output: sarif-results
 
     - name: adjust-cvss
-      uses: advanced-security/adjust-cvss@master
+      uses: ./
       with:
         #patterns: |
         #  -**/*.java
@@ -61,12 +61,12 @@ jobs:
         output: sarif-results/${{ matrix.language }}.sarif
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
       with:
         sarif_file: sarif-results/${{ matrix.language }}.sarif
 
     - name: Upload loc as a Build Artifact
-      uses: actions/upload-artifact@v2.2.0
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: sarif-results
         path: sarif-results


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/adjust-cvss/security/code-scanning/61](https://github.com/advanced-security/adjust-cvss/security/code-scanning/61)

To fix the problem, explicitly add a `permissions` block to restrict the GITHUB_TOKEN to the least privilege necessary. The best way to do this is to add the `permissions` key to the job in question (or at the workflow root if all jobs should have the same restriction). Since none of the actions in the `analyze` job appear to require write access, the minimal value, `contents: read`, is sufficient. Add the following block at the same indentation level as `runs-on` in the `analyze` job:

```yaml
permissions:
  contents: read
```

Add it between `name: Analyze` and `runs-on: ubuntu-latest` (i.e., after line 20, before line 21).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
