### PR TITLE
Potential fix for code scanning alert no. 67: Code injection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: adjust
       env:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
-        INPUT: {{ inputs.input }}
+        INPUT: ${{ inputs.input }}
         OUTPUT: ${{ inputs.output }}
         PATTERNS: ${{ inputs.patterns }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,9 @@ runs:
   using: "composite"
   steps:
     - name: adjust
+      env:
+        PATTERNS: ${{ inputs.patterns }}
       run: |
         unset LD_PRELOAD
-        python3 "${{ github.action_path }}/adjust_cvss.py" --input "${{ inputs.input }}" --output "${{ inputs.output }}" --split-lines -- "${{ inputs.patterns }}"
+        python3 "${{ github.action_path }}/adjust_cvss.py" --input "${{ inputs.input }}" --output "${{ inputs.output }}" --split-lines -- "$PATTERNS"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,11 @@ runs:
   steps:
     - name: adjust
       env:
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
+        INPUT: {{ inputs.input }}
+        OUTPUT: ${{ inputs.output }}
         PATTERNS: ${{ inputs.patterns }}
       run: |
         unset LD_PRELOAD
-        python3 "${{ github.action_path }}/adjust_cvss.py" --input "${{ inputs.input }}" --output "${{ inputs.output }}" --split-lines -- "$PATTERNS"
+        python3 "$GITHUB_ACTION_PATH/adjust_cvss.py" --input "$INPUT" --output "$OUTPUT" --split-lines -- "$PATTERNS"
       shell: bash


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/adjust-cvss/security/code-scanning/67](https://github.com/advanced-security/adjust-cvss/security/code-scanning/67)

To fix this code injection vulnerability, the input variable `${{ inputs.patterns }}` should not be interpolated directly into the shell command. Instead, pass the value through an environment variable, and reference it using pure shell variable expansion (`"$PATTERNS"`) in the script. This ensures that the shell receives the argument value as a single token, regardless of its content, and does not allow the code injection vector. 

Specifically, add an `env` section to set `PATTERNS` using `${{ inputs.patterns }}` as its value. Then, update the command so that instead of directly using `"${{ inputs.patterns }}"`, it uses `"$PATTERNS"`.  
You only need to update the relevant `run` step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
